### PR TITLE
Add LOVELACE_REMOTE_FILES support and update Home Assistant version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.13
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian stable main" > /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bluez \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The default action of the image is to run `container`, which will
 | `HASS_PASSWORD` | The password of the default user | `dev` |
 | `LOVELACE_PLUGINS` | List of lovelac plugins to download from github | Empty |
 | `LOVELACE_LOCAL_FILES` | List of filenames in `/config/www/workspace` to add as lovelace resources | Emtpy |
+| `LOVELACE_REMOTE_FILES` | List of full URLs to remotely served lovelace resources to add to lovelace configuration | Empty |
 
 ### About Lovelace Plugins
 The dowload and install of plugins is *very* basic. This is not HACS.
@@ -37,6 +38,8 @@ The dowload and install of plugins is *very* basic. This is not HACS.
 `LOVELACE_PLUGINS` should be a space separated list of author/repo pairs, e.g. `"thomasloven/lovelace-card-mod  kalkih/mini-media-player"`
 
 `LOVELACE_LOCAL_FILES` is for the currently worked on plugins and should be a list of file names which are mounted in `/config/www/workspace`.
+
+`LOVELACE_REMOTE_FILES` is for plugins served remotely (e.g. by a local dev server) and should be a space separated list of full URLs including host and port, e.g. `"http://localhost:5000/my-card.js http://localhost:5001/other-card.js"`. The URLs are used as-is in the lovelace resources configuration.
 
 ### Container Script
 

--- a/container
+++ b/container
@@ -60,6 +60,11 @@ function install_lovelace_plugins() {
         plugins="${plugins} /local/workspace/${file}"
     done
 
+    for file in $LOVELACE_REMOTE_FILES
+    do
+        plugins="${plugins} ${file}"
+    done
+
     fetch_lovelace_plugins
 
     cat > /config/.storage/lovelace_resources << EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-homeassistant==2025.3.4
+homeassistant==2026.2.3


### PR DESCRIPTION
This pull request introduces support for specifying remote Lovelace resources in addition to local files and plugins. The main changes are the addition of the `LOVELACE_REMOTE_FILES` environment variable and the necessary updates to documentation and container logic to handle remote resources.

Lovelace remote resource support:

* Added `LOVELACE_REMOTE_FILES` environment variable to the `README.md`, allowing users to specify a list of full URLs for remotely served Lovelace resources.
* Updated documentation to explain how `LOVELACE_REMOTE_FILES` works, including usage examples and its purpose for plugins served remotely.
* Modified the `container` script to append remote files specified in `LOVELACE_REMOTE_FILES` to the list of Lovelace plugins/resources, ensuring they are added to the configuration.